### PR TITLE
Pull useful improvements from Community

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
         overwrite: true
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif
 

--- a/action.yml
+++ b/action.yml
@@ -113,10 +113,11 @@ runs:
         INPUT_INI_PATH: ${{ inputs.ini_path }}        
 
     - name: Upload artifact
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: results.sarif
         path: results.sarif
+        overwrite: true
 
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@v2

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'path to a .bandit file that supplies command line arguments'
     required: false
     default: 'DEFAULT'
+  config_path:
+    description: 'path to a YAML or TOML file that supplies command line arguments'
+    required: false
+    default: 'DEFAULT'
   GITHUB_TOKEN:
     description: 'Github token of the repository (automatically created by Github)'
     required: true
@@ -102,7 +106,13 @@ runs:
         else
             INI_PATH="--ini $INPUT_INI_PATH"
         fi
-        bandit -f sarif -o results.sarif -r $INPUT_PATH $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH
+
+        if [ "$INPUT_CONFIG_PATH" == "DEFAULT" ]; then
+            CONFIG_PATH=""
+        else
+            CONFIG_PATH="-c $INPUT_CONFIG_PATH"
+        fi
+        bandit -f sarif -o results.sarif -r $INPUT_PATH $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH $CONFIG_PATH
       env:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_LEVEL: ${{ inputs.level }}
@@ -110,7 +120,8 @@ runs:
         INPUT_EXCLUDED_PATHS: ${{ inputs.excluded_paths }}
         INPUT_EXIT_ZERO: ${{ inputs.exit_zero }}
         INPUT_SKIPS: ${{ inputs.skips }}
-        INPUT_INI_PATH: ${{ inputs.ini_path }}        
+        INPUT_INI_PATH: ${{ inputs.ini_path }}
+        INPUT_CONFIG_PATH: ${{ inputs.config_path }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Pull useful improvements from community

## Pull new configuration input feature from related work in community

* Incorporate the feature to optionally include a `config_path` input to allow further configuration of `bandit`

## Partial version bumps for action dependancies

* Updating to `github/code-action/upload-sarif@v3` presents no significant changes since `v2` besides the underlying node version. Details in [relevant project README](https://github.com/github/codeql-action?tab=readme-ov-file#supported-versions-of-the-codeql-action)

* Updating to `actions/upload-artifact@v4` brings significant changes we should be aware of. The maintainers have noted that version 4 introduces breaking changes:

    * **GitHub Enterprise Server (GHES) Compatibility**: Support for GHES versions prior to 3.5 has been discontinued. If you're using an older GHES version, this update might not be compatible.
    * **Default Behavior Adjustments**: There may be changes to default configurations, such as the default value for retention-days. Deprecated inputs or features might have been removed as well.

  For a comprehensive understanding of these impacts and to ensure seamless integration, please review the maintainers' notes in the [upload-artifact project README](https://github.com/actions/upload-artifact#actionsupload-artifact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `config_path` parameter for the Bandit Scan action, allowing users to specify a configuration file for command line arguments.

- **Improvements**
	- Updated artifact upload steps to use the latest versions of the actions, enhancing reliability and functionality. 
	- Added an option to overwrite existing artifacts during upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->